### PR TITLE
Add proxy configuration capability to the Vinted client

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ vinted = Vinted()
 vinted = Vinted(domain="fr")
 ```
 
+* To use a proxy for API requests, you can configure it when initializing the Vinted object:
+```python
+# Configure proxy settings
+proxy_settings = {
+    'username': 'your_proxy_username',
+    'password': 'your_proxy_password',
+    'host': 'proxy_host',
+    'port': 'proxy_port'
+}
+
+# Create proxy URL
+proxy_url = f"http://{proxy_settings['username']}:{proxy_settings['password']}@{proxy_settings['host']}:{proxy_settings['port']}"
+
+# Initialize Vinted with proxy
+vinted = Vinted(domain="fr", proxy=proxy_url)
+```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/vinted/vinted.py
+++ b/vinted/vinted.py
@@ -24,7 +24,14 @@ class Vinted:
     def __init__(
         self,
         domain: Domain = "pl",
+        proxy: str = None
     ) -> None:
+        self.proxy = None
+        if proxy:
+            self.proxy = {
+                'http': proxy,
+                'https': proxy
+            }
         self.base_url = f"https://www.vinted.{domain}"
         self.api_url = f"{self.base_url}/api/v2"
         self.headers = {
@@ -33,7 +40,7 @@ class Vinted:
         self.cookies = self.fetch_cookies()
 
     def fetch_cookies(self):
-        response = requests.get(self.base_url, headers=self.headers)
+        response = requests.get(self.base_url, headers=self.headers, proxies=self.proxy)
         return response.cookies
 
     def _call(self, method: Literal["get"], *args, **kwargs):
@@ -56,7 +63,7 @@ class Vinted:
             kwargs["url"] = updated_url
 
         return requests.request(
-            method=method, headers=self.headers, cookies=self.cookies, *args, **kwargs
+            method=method, headers=self.headers, cookies=self.cookies, proxies=self.proxy, *args, **kwargs
         )
 
     def _get(


### PR DESCRIPTION
## Add proxy support to Vinted client

### Changes
- Added optional proxy support to Vinted class
- Moved proxy configuration to external file
- Made proxy usage conditional based on configuration

### Implementation
```python
# Configure proxy in main.py
proxy_settings = {
    'username': 'xxx',
    'password': 'xxx',
    'host': 'xxx',
    'port': 'xxx'
}

# Pass to Vinted client
vinted = Vinted(domain="it", proxy=proxy_url)
```

### Testing
- Verified all API endpoints work with proxy
- Confirmed backward compatibility (works without proxy)
